### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ NOTE: currently the set of features is minimal but I hope to extend them soon.
 ## Requirements
 
 * iOS 8.0+
-* XCode 7.1+
+* Xcode 7.1+
 
 ## Installation
 


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
